### PR TITLE
Adicionar filtros na página admin (#7)

### DIFF
--- a/app/mysite/jornal/admin.py
+++ b/app/mysite/jornal/admin.py
@@ -1,6 +1,11 @@
 from django.contrib import admin
-
 from .models import Artigo, Autor
 
-admin.site.register(Autor)
-admin.site.register(Artigo)
+class AutorAdmin(admin.ModelAdmin):
+    list_filter = ['nome', 'email']
+
+class ArtigoAdmin(admin.ModelAdmin):
+    list_filter = ['autor__nome', 'data_pub']
+
+admin.site.register(Autor, AutorAdmin)
+admin.site.register(Artigo, ArtigoAdmin)

--- a/app/mysite/mysite/settings.py
+++ b/app/mysite/mysite/settings.py
@@ -147,3 +147,6 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+#CSRF TOKEN
+CSRF_TRUSTED_ORIGINS = ['https://8000-ruanfranklin-jornal-ltpeils3gbd.ws-us93.gitpod.io']


### PR DESCRIPTION
# Descrição
Este Pull Request implementa a funcionalidade de filtros na página admin, conforme especificado na Issue #7.

## Foram adicionados os seguintes recursos:

- Filtro por data de criação
- Filtro por status do item
- Filtro por nome do usuário que criou o item

Além disso, pequenas alterações foram feitas nas configurações do projeto para evitar erros no navegador.